### PR TITLE
Patch taa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -651,6 +651,13 @@ description = "Showcases wireframe rendering"
 category = "3D Rendering"
 wasm = true
 
+[[example]]
+name = "no_prepass"
+path = "tests/3d/no_prepass.rs"
+
+[package.metadata.example.no_prepass]
+hidden = true
+
 # Animation
 [[example]]
 name = "animated_fox"

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -74,28 +74,32 @@ impl Node for PrepassNode {
         }
 
         let mut color_attachments = vec![];
-        color_attachments.push(view_prepass_textures.normal.as_ref().map( |view_normals_texture|
-            RenderPassColorAttachment {
-                view: &view_normals_texture.default_view,
+        color_attachments.push(
+            view_prepass_textures
+                .normal
+                .as_ref()
+                .map(|view_normals_texture| RenderPassColorAttachment {
+                    view: &view_normals_texture.default_view,
+                    resolve_target: None,
+                    ops: Operations {
+                        load: LoadOp::Clear(Color::BLACK.into()),
+                        store: true,
+                    },
+                }),
+        );
+
+        color_attachments.push(view_prepass_textures.motion_vectors.as_ref().map(
+            |view_motion_vectors_texture| RenderPassColorAttachment {
+                view: &view_motion_vectors_texture.default_view,
                 resolve_target: None,
                 ops: Operations {
-                    load: LoadOp::Clear(Color::BLACK.into()),
+                    // Blue channel dosen't matter, but set to 1.0 for possible faster clear
+                    // https://gpuopen.com/performance/#clears
+                    load: LoadOp::Clear(Color::rgb_linear(1.0, 1.0, 1.0).into()),
                     store: true,
                 },
-            }
-        ));
-
-        color_attachments.push(view_prepass_textures.motion_vectors.as_ref().map(|view_motion_vectors_texture|
-            RenderPassColorAttachment {
-            view: &view_motion_vectors_texture.default_view,
-            resolve_target: None,
-            ops: Operations {
-                // Blue channel dosen't matter, but set to 1.0 for possible faster clear
-                // https://gpuopen.com/performance/#clears
-                load: LoadOp::Clear(Color::rgb_linear(1.0, 1.0, 1.0).into()),
-                store: true,
             },
-        }));
+        ));
 
         if color_attachments.iter().all(Option::is_none) {
             // all attachments are none: clear the attachment list so that no fragment shader is required

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -74,29 +74,32 @@ impl Node for PrepassNode {
         }
 
         let mut color_attachments = vec![];
-        if let Some(view_normals_texture) = &view_prepass_textures.normal {
-            color_attachments.push(Some(RenderPassColorAttachment {
+        color_attachments.push(view_prepass_textures.normal.as_ref().map( |view_normals_texture|
+            RenderPassColorAttachment {
                 view: &view_normals_texture.default_view,
                 resolve_target: None,
                 ops: Operations {
                     load: LoadOp::Clear(Color::BLACK.into()),
                     store: true,
                 },
-            }));
-        } else {
-            color_attachments.push(None);
-        }
-        if let Some(view_motion_vectors_texture) = &view_prepass_textures.motion_vectors {
-            color_attachments.push(Some(RenderPassColorAttachment {
-                view: &view_motion_vectors_texture.default_view,
-                resolve_target: None,
-                ops: Operations {
-                    // Blue channel dosen't matter, but set to 1.0 for possible faster clear
-                    // https://gpuopen.com/performance/#clears
-                    load: LoadOp::Clear(Color::rgb_linear(1.0, 1.0, 1.0).into()),
-                    store: true,
-                },
-            }));
+            }
+        ));
+
+        color_attachments.push(view_prepass_textures.motion_vectors.as_ref().map(|view_motion_vectors_texture|
+            RenderPassColorAttachment {
+            view: &view_motion_vectors_texture.default_view,
+            resolve_target: None,
+            ops: Operations {
+                // Blue channel dosen't matter, but set to 1.0 for possible faster clear
+                // https://gpuopen.com/performance/#clears
+                load: LoadOp::Clear(Color::rgb_linear(1.0, 1.0, 1.0).into()),
+                store: true,
+            },
+        }));
+
+        if color_attachments.iter().all(Option::is_none) {
+            // all attachments are none: clear the attachment list so that no fragment shader is required
+            color_attachments.clear();
         }
 
         {

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -136,6 +136,7 @@ pub struct TemporalAntialiasBundle {
 /// Cannot be used with [`bevy_render::camera::OrthographicProjection`].
 ///
 /// Currently does not support skinned meshes. There will probably be ghosting artifacts if used with them.
+/// Does not work well with alpha-blended meshes as it requires depth writing to determine motion.
 ///
 /// It is very important that correct motion vectors are written for everything on screen.
 /// Failure to do so will lead to ghosting artifacts. For instance, if particle effects

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -484,7 +484,7 @@ fn prepare_taa_jitter(
     let offset = halton_sequence[frame_count.0 as usize % halton_sequence.len()];
 
     for mut jitter in &mut query {
-        jitter.offset = offset;
+        jitter.offset = offset - 0.5;
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -37,14 +37,18 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     fn dyn_clone(&self) -> Box<dyn SystemSet>;
 }
 
-/// A system set that is never contained in another set.
-/// Systems and other system sets may only belong to one base set.
+/// A marker trait for `SystemSet` types where [`is_base`] returns `true`.
+/// This should only be implemented for types that satisfy this requirement.
+/// It is automatically implemented for base set types by `#[derive(SystemSet)]`.
 ///
-/// This should only be implemented for types that return `true` from [`SystemSet::is_base`].
+/// [`is_base`]: SystemSet::is_base
 pub trait BaseSystemSet: SystemSet {}
 
-/// System sets that are *not* base sets. This should not be implemented for
-/// any types that implement [`BaseSystemSet`].
+/// A marker trait for `SystemSet` types where [`is_base`] returns `false`.
+/// This should only be implemented for types that satisfy this requirement.
+/// It is automatically implemented for non-base set types by `#[derive(SystemSet)]`.
+///
+/// [`is_base`]: SystemSet::is_base
 pub trait FreeSystemSet: SystemSet {}
 
 impl PartialEq for dyn SystemSet {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,7 @@
 use crate::{
     render, AlphaMode, DrawMesh, DrawPrepass, EnvironmentMapLight, MeshPipeline, MeshPipelineKey,
-    MeshUniform, PrepassPlugin, RenderLightSystems, SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
+    MeshUniform, PrepassPipelinePlugin, PrepassPlugin, RenderLightSystems, SetMeshBindGroup,
+    SetMeshViewBindGroup, Shadow,
 };
 use bevy_app::{App, IntoSystemAppConfig, Plugin};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
@@ -206,6 +207,9 @@ where
                 .add_system(render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows))
                 .add_system(queue_material_meshes::<M>.in_set(RenderSet::Queue));
         }
+
+        // PrepassPipelinePlugin is required for shadow mapping and the optional PrepassPlugin
+        app.add_plugin(PrepassPipelinePlugin::<M>::default());
 
         if self.prepass_enabled {
             app.add_plugin(PrepassPlugin::<M>::default());

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,7 +1,6 @@
 use crate::{
-    queue_mesh_view_bind_groups, render, AlphaMode, DrawMesh, DrawPrepass, EnvironmentMapLight,
-    MeshPipeline, MeshPipelineKey, MeshUniform, PrepassPlugin, RenderLightSystems,
-    SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
+    render, AlphaMode, DrawMesh, DrawPrepass, EnvironmentMapLight, MeshPipeline, MeshPipelineKey,
+    MeshUniform, PrepassPlugin, RenderLightSystems, SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
 };
 use bevy_app::{App, IntoSystemAppConfig, Plugin};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
@@ -205,11 +204,6 @@ where
                         .after(PrepareAssetSet::PreAssetPrepare),
                 )
                 .add_system(render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows))
-                .add_system(
-                    render::queue_shadow_view_bind_group::<M>
-                        .in_set(RenderSet::Queue)
-                        .ambiguous_with(queue_mesh_view_bind_groups), // queue_mesh_view_bind_groups does not read `shadow_view_bind_group`),
-                )
                 .add_system(queue_material_meshes::<M>.in_set(RenderSet::Queue));
         }
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -59,15 +59,18 @@ pub const PREPASS_BINDINGS_SHADER_HANDLE: HandleUntyped =
 pub const PREPASS_UTILS_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 4603948296044544);
 
-pub struct PrepassPlugin<M: Material>(PhantomData<M>);
+/// Sets up everything required to use the prepass pipeline.
+///
+/// This does not add the actual prepasses, see [`PrepassPlugin`] for that.
+pub struct PrepassPipelinePlugin<M: Material>(PhantomData<M>);
 
-impl<M: Material> Default for PrepassPlugin<M> {
+impl<M: Material> Default for PrepassPipelinePlugin<M> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<M: Material> Plugin for PrepassPlugin<M>
+impl<M: Material> Plugin for PrepassPipelinePlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
@@ -94,6 +97,34 @@ where
         );
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+                return;
+            };
+
+        render_app
+            .add_system(queue_prepass_view_bind_group::<M>.in_set(RenderSet::Queue))
+            .init_resource::<PrepassPipeline<M>>()
+            .init_resource::<PrepassViewBindGroup>()
+            .init_resource::<SpecializedMeshPipelines<PrepassPipeline<M>>>();
+    }
+}
+
+/// Sets up the prepasses for a [`Material`].
+///
+/// This depends on the [`PrepassPipelinePlugin`].
+pub struct PrepassPlugin<M: Material>(PhantomData<M>);
+
+impl<M: Material> Default for PrepassPlugin<M> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<M: Material> Plugin for PrepassPlugin<M>
+where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
+    fn build(&self, app: &mut bevy_app::App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
@@ -104,15 +135,11 @@ where
                     .in_set(RenderSet::Prepare)
                     .after(bevy_render::view::prepare_windows),
             )
-            .add_system(queue_prepass_view_bind_group::<M>.in_set(RenderSet::Queue))
             .add_system(queue_prepass_material_meshes::<M>.in_set(RenderSet::Queue))
             .add_system(sort_phase_system::<Opaque3dPrepass>.in_set(RenderSet::PhaseSort))
             .add_system(sort_phase_system::<AlphaMask3dPrepass>.in_set(RenderSet::PhaseSort))
-            .init_resource::<PrepassPipeline<M>>()
             .init_resource::<DrawFunctions<Opaque3dPrepass>>()
             .init_resource::<DrawFunctions<AlphaMask3dPrepass>>()
-            .init_resource::<PrepassViewBindGroup>()
-            .init_resource::<SpecializedMeshPipelines<PrepassPipeline<M>>>()
             .add_render_command::<Opaque3dPrepass, DrawPrepass<M>>()
             .add_render_command::<AlphaMask3dPrepass, DrawPrepass<M>>();
     }
@@ -254,11 +281,12 @@ where
 
         let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;
 
-        // The fragment shader is only used when the normal prepass is enabled or the material uses alpha cutoff values
-        let fragment = if key
-            .mesh_key
-            .intersects(MeshPipelineKey::NORMAL_PREPASS | MeshPipelineKey::ALPHA_MASK)
-            || blend_key == MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA
+        // The fragment shader is only used when the normal prepass is enabled
+        // or the material uses alpha cutoff values and doesn't rely on the standard prepass shader
+        let fragment = if key.mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS)
+            || ((key.mesh_key.contains(MeshPipelineKey::ALPHA_MASK)
+                || blend_key == MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA)
+                && self.material_fragment_shader.is_some())
         {
             // Use the fragment shader from the material if present
             let frag_shader_handle = if let Some(handle) = &self.material_fragment_shader {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -357,18 +357,25 @@ where
 
         // Setup prepass fragment targets - normals in slot 0 (or None if not needed), motion vectors in slot 1
         let mut targets = vec![];
-        targets.push(key.mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS).then(|| ColorTargetState {
-                format: NORMAL_PREPASS_FORMAT,
-                blend: Some(BlendState::REPLACE),
-                write_mask: ColorWrites::ALL,
-            })
+        targets.push(
+            key.mesh_key
+                .contains(MeshPipelineKey::NORMAL_PREPASS)
+                .then_some(ColorTargetState {
+                    format: NORMAL_PREPASS_FORMAT,
+                    blend: Some(BlendState::REPLACE),
+                    write_mask: ColorWrites::ALL,
+                }),
         );
-        
-        targets.push(key.mesh_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS).then(|| ColorTargetState {
-            format: MOTION_VECTOR_PREPASS_FORMAT,
-            blend: Some(BlendState::REPLACE),
-            write_mask: ColorWrites::ALL,
-        }));
+
+        targets.push(
+            key.mesh_key
+                .contains(MeshPipelineKey::MOTION_VECTOR_PREPASS)
+                .then_some(ColorTargetState {
+                    format: MOTION_VECTOR_PREPASS_FORMAT,
+                    blend: Some(BlendState::REPLACE),
+                    write_mask: ColorWrites::ALL,
+                }),
+        );
 
         if targets.iter().all(Option::is_none) {
             // if no targets are required then clear the list, so that no fragment shader is required
@@ -378,7 +385,9 @@ where
 
         // The fragment shader is only used when the normal prepass or motion vectors prepass
         // is enabled or the material uses alpha cutoff values
-        let fragment_required = key.mesh_key.intersects(MeshPipelineKey::ALPHA_MASK | MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA)
+        let fragment_required = key
+            .mesh_key
+            .intersects(MeshPipelineKey::ALPHA_MASK | MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA)
             || !targets.is_empty();
 
         let fragment = fragment_required.then(|| {

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -100,6 +100,7 @@ impl Plugin for TransformPlugin {
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
             // add transform systems to startup so the first update is "correct"
             .configure_set(TransformSystem::TransformPropagate.in_base_set(CoreSet::PostUpdate))
+            .configure_set(PropagateTransformsSet.in_set(TransformSystem::TransformPropagate))
             .edit_schedule(CoreSchedule::Startup, |schedule| {
                 schedule.configure_set(
                     TransformSystem::TransformPropagate.in_base_set(StartupSet::PostStartup),
@@ -113,20 +114,12 @@ impl Plugin for TransformPlugin {
                     .in_set(TransformSystem::TransformPropagate)
                     .ambiguous_with(PropagateTransformsSet),
             )
-            .add_startup_system(
-                propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(PropagateTransformsSet),
-            )
+            .add_startup_system(propagate_transforms.in_set(PropagateTransformsSet))
             .add_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
                     .ambiguous_with(PropagateTransformsSet),
             )
-            .add_system(
-                propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(PropagateTransformsSet),
-            );
+            .add_system(propagate_transforms.in_set(PropagateTransformsSet));
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -9,6 +9,7 @@ mod render;
 mod stack;
 mod ui_node;
 
+#[cfg(feature = "bevy_text")]
 mod accessibility;
 pub mod camera_config;
 pub mod node_bundles;
@@ -103,7 +104,6 @@ impl Plugin for UiPlugin {
             .register_type::<Val>()
             .register_type::<widget::Button>()
             .register_type::<widget::Label>()
-            .add_plugin(accessibility::AccessibilityPlugin)
             .configure_set(UiSystem::Focus.in_base_set(CoreSet::PreUpdate))
             .configure_set(UiSystem::Flex.in_base_set(CoreSet::PostUpdate))
             .configure_set(UiSystem::Stack.in_base_set(CoreSet::PostUpdate))
@@ -124,6 +124,8 @@ impl Plugin for UiPlugin {
                 // they will never observe each other's effects.
                 .ambiguous_with(bevy_text::update_text2d_layout),
         );
+        #[cfg(feature = "bevy_text")]
+        app.add_plugin(accessibility::AccessibilityPlugin);
         app.add_system({
             let system = widget::update_image_calculated_size_system
                 .in_base_set(CoreSet::PostUpdate)

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -275,7 +275,13 @@ pub struct Style {
     /// ```
     /// A node with this style and a parent with dimensions of 300px by 100px, will have calculated padding of 3px on the left, 6px on the right, 9px on the top and 12px on the bottom.
     pub padding: UiRect,
-    /// The border of the node
+    /// The amount of space between the margins of a node and its padding.
+    ///
+    /// If a percentage value is used, the percentage is calculated based on the width of the parent node.
+    ///
+    /// The size of the node will be expanded if there are constraints that prevent the layout algorithm from placing the border within the existing node boundary.
+    ///
+    /// Rendering for borders is not yet implemented.
     pub border: UiRect,
     /// Defines how much a flexbox item should grow if there's space available
     pub flex_grow: f32,

--- a/tests/3d/no_prepass.rs
+++ b/tests/3d/no_prepass.rs
@@ -1,0 +1,11 @@
+//! A test to confirm that `bevy` allows disabling the prepass of the standard material.
+//! This is run in CI to ensure that this doesn't regress again.
+use bevy::{pbr::PbrPlugin, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(PbrPlugin {
+            prepass_enabled: false,
+        }))
+        .run();
+}


### PR DESCRIPTION
- merge main
- fix target/attach vecs (as materials can now provide a None fragment shader we must clear the target and the attachment vecs when all components are none to support that).
- center jitter by subtracting 0.5 (there was a noticeable shift down+right on the anti-aliasing example when switching to TAA)
- add a comment about lack of support for alpha-blend materials