### PR TITLE
handwritten bit packing/unpacking for dx12

### DIFF
--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -53,10 +53,18 @@ fn calculate_neighboring_depth_differences(pixel_coordinates: vec2<i32>) -> f32 
     edge_info = saturate((1.0 + bias) - edge_info / scale); // Apply the bias and scale, and invert edge_info so that small values become large, and vice versa
 
     // Pack the edge info into the texture
-    let edge_info_packed = vec4<u32>(pack4x8unorm(edge_info), 0u, 0u, 0u);
+    let edge_info_packed = vec4<u32>(mypack4x8unorm(edge_info), 0u, 0u, 0u);
     textureStore(depth_differences, pixel_coordinates, edge_info_packed);
 
     return depth_center;
+}
+
+// TODO: Remove this once https://github.com/gfx-rs/naga/pull/2353 lands
+fn mypack4x8unorm(e: vec4<f32>) -> u32 {
+    return u32(clamp(e.x, 0.0, 1.0) * 255.0 + 0.5) |
+    u32(clamp(e.y, 0.0, 1.0) * 255.0 + 0.5) << 8u |
+    u32(clamp(e.z, 0.0, 1.0) * 255.0 + 0.5) << 16u |
+    u32(clamp(e.w, 0.0, 1.0) * 255.0 + 0.5) << 24u;
 }
 
 fn load_normal_view_space(uv: vec2<f32>) -> vec3<f32> {

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
@@ -31,11 +31,11 @@ fn spatial_denoise(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let visibility2 = textureGather(0, ambient_occlusion_noisy, point_clamp_sampler, uv, vec2<i32>(0i, 2i));
     let visibility3 = textureGather(0, ambient_occlusion_noisy, point_clamp_sampler, uv, vec2<i32>(2i, 2i));
 
-    let left_edges = unpack4x8unorm(edges0.x);
-    let right_edges = unpack4x8unorm(edges1.x);
-    let top_edges = unpack4x8unorm(edges0.z);
-    let bottom_edges = unpack4x8unorm(edges2.w);
-    var center_edges = unpack4x8unorm(edges0.y);
+    let left_edges = myunpack4x8unorm(edges0.x);
+    let right_edges = myunpack4x8unorm(edges1.x);
+    let top_edges = myunpack4x8unorm(edges0.z);
+    let bottom_edges = myunpack4x8unorm(edges2.w);
+    var center_edges = myunpack4x8unorm(edges0.y);
     center_edges *= vec4<f32>(left_edges.y, right_edges.x, top_edges.w, bottom_edges.z);
 
     let center_weight = 1.2;
@@ -81,4 +81,12 @@ fn spatial_denoise(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let denoised_visibility = sum / sum_weight;
 
     textureStore(ambient_occlusion, pixel_coordinates, vec4<f32>(denoised_visibility, 0.0, 0.0, 0.0));
+}
+
+// TODO: Remove this once https://github.com/gfx-rs/naga/pull/2353 lands in Bevy
+fn myunpack4x8unorm(e: u32) -> vec4<f32> {
+    return vec4<f32>(clamp(f32(e & 0xFFu) / 255.0, 0.0, 1.0),
+        clamp(f32((e >> 8u) & 0xFFu) / 255.0, 0.0, 1.0),
+        clamp(f32((e >> 16u) & 0xFFu) / 255.0, 0.0, 1.0),
+        clamp(f32((e >> 24u) & 0xFFu) / 255.0, 0.0, 1.0));
 }


### PR DESCRIPTION
This replaces the `pack4x8unorm` and `unpack4x8unorm` calls with handwritten impls for dx12 support.

Imo it'd be nice to have these if SSAO lands in the next bevy release, since https://github.com/gfx-rs/naga/pull/2353 probably won't get backported.

Hopefully we can get the wgpu dx12 bugfix backported as well.