### PR TITLE
Optimise extract_meshlet_meshes and prepare_meshlet_per_frame_resources

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -26,7 +26,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
   "bevy",
 ] }
 bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 bevy_window = { path = "../bevy_window", version = "0.12.0" }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -26,6 +26,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
   "bevy",
 ] }
 bevy_render = { path = "../bevy_render", version = "0.12.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 bevy_window = { path = "../bevy_window", version = "0.12.0" }

--- a/crates/bevy_pbr/src/meshlet/gpu_scene.rs
+++ b/crates/bevy_pbr/src/meshlet/gpu_scene.rs
@@ -745,18 +745,16 @@ impl MeshletGpuScene {
             .previous_thread_id_starts
             .entry((instance, handle.id()))
             .or_insert((0, true));
+        let previous_thread_ids = if previous_thread_id_start.1 {
+            0..(meshlets_slice.len() as u32)
+        } else {
+            let start = previous_thread_id_start.0;
+            start..(meshlets_slice.len() as u32 + start)
+        };
 
-        for (i, meshlet_index) in meshlets_slice.into_iter().enumerate() {
-            self.thread_instance_ids.get_mut().push(instance_index);
-            self.thread_meshlet_ids.get_mut().push(meshlet_index);
-            self.previous_thread_ids
-                .get_mut()
-                .push(if previous_thread_id_start.1 {
-                    0
-                } else {
-                    previous_thread_id_start.0 + i as u32
-                });
-        }
+        self.thread_instance_ids.get_mut().extend(std::iter::repeat(instance_index).take(meshlets_slice.len()));
+        self.thread_meshlet_ids.get_mut().extend(meshlets_slice);
+        self.previous_thread_ids.get_mut().extend(previous_thread_ids);
 
         *previous_thread_id_start = (current_thread_id_start, true);
     }


### PR DESCRIPTION
# Objective

- In `extract_meshlet_meshes` there is a tight loop which performs badly
- In `prepare_meshlet_per_frame_resources` several redundant memory copies happen

## Solution

- In `extract_meshlet_meshes`, replace the loop with several `extend()` calls, which will improve locality and reduce number of capacity checks
- In `prepare_meshlet_per_frame_resources` copy directly from the Pod-compatible storage buffers into GPU memory
