### PR TITLE
Don't lock external edges during simplification

### DIFF
--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -188,6 +188,8 @@ fn compute_mesh_boundary(indices: &[u32], result: &mut [bool]) {
             }
         }
     }
+
+    result.fill(false);
     for (v0, v1) in border_edge_set {
         result[v0 as usize] = true;
         result[v1 as usize] = true;


### PR DESCRIPTION
# Objective
Only lock the edges internal to a mesh when simplifying groups, such that non-solid meshes will still have their edges simplified, leading to much better performance at lower LOD levels.

## Solution

We generate a list of edge vertices at the beginning of the import, which define the border of the mesh as a whole. Then, when a group is being simplified, we calculate the border of the group, and remove any vertices that are in the mesh border.

The current implementation seriously affects the performance of the builder, since the entire vertex buffer has to be traversed to find the differences between the mesh border and group border. This can probably be optimized by generating a mini-vertex buffer for each group. The border computation code isn't particularly well-optimized either.
