### PR TITLE
Add a `--bicubic` switch to the `lightmaps` example

### DIFF
--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -13,6 +13,9 @@ struct Args {
     /// enables deferred shading
     #[argh(switch)]
     deferred: bool,
+    /// enables bicubic filtering
+    #[argh(switch)]
+    bicubic: bool,
 }
 
 fn main() {
@@ -63,6 +66,7 @@ fn add_lightmaps_to_meshes(
         (Entity, &Name, &MeshMaterial3d<StandardMaterial>),
         (With<Mesh3d>, Without<Lightmap>),
     >,
+    args: Res<Args>,
 ) {
     let exposure = 250.0;
     for (entity, name, material) in meshes.iter() {
@@ -70,6 +74,7 @@ fn add_lightmaps_to_meshes(
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
                 image: asset_server.load("lightmaps/CornellBox-Large.zstd.ktx2"),
+                bicubic_sampling: args.bicubic,
                 ..default()
             });
             continue;
@@ -79,6 +84,7 @@ fn add_lightmaps_to_meshes(
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
                 image: asset_server.load("lightmaps/CornellBox-Small.zstd.ktx2"),
+                bicubic_sampling: args.bicubic,
                 ..default()
             });
             continue;
@@ -88,6 +94,7 @@ fn add_lightmaps_to_meshes(
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
                 image: asset_server.load("lightmaps/CornellBox-Box.zstd.ktx2"),
+                bicubic_sampling: args.bicubic,
                 ..default()
             });
             continue;


### PR DESCRIPTION
Part of https://github.com/bevyengine/bevy/pull/16740