### PR TITLE
restore fallback behaviour for dx12 compiler

### DIFF
--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -104,9 +104,19 @@ impl Default for WgpuSettings {
             Dx12Compiler::from_env().unwrap_or(if cfg!(feature = "statically-linked-dxc") {
                 Dx12Compiler::StaticDxc
             } else {
-                Dx12Compiler::DynamicDxc {
-                    dxc_path: String::from("dxcompiler.dll"),
-                    dxil_path: String::from("dxil.dll"),
+                let dxc = "dxcompiler.dll";
+                let dxil = "dxil.dll";
+
+                if cfg!(target_os = "windows")
+                    && std::fs::metadata(dxc).is_ok()
+                    && std::fs::metadata(dxil).is_ok()
+                {
+                    Dx12Compiler::DynamicDxc {
+                        dxc_path: String::from(dxc),
+                        dxil_path: String::from(dxil),
+                    }
+                } else {
+                    Dx12Compiler::Fxc
                 }
             });
 


### PR DESCRIPTION
# Objective

- Fix CI on Windows in DX12

## Solution

- Restore fallback behaviour of `Dx12Compiler`


[`Dx12Compiler::Dxc`](https://docs.rs/wgpu/23.0.1/wgpu/enum.Dx12Compiler.html) in wgpu 23 fallbacked to `Dx12Compiler::Fxc` when the dlls were not found. Restore that